### PR TITLE
ci: add GitHub dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Maintain golang dependencies defined in go.mod
+  # These would open PR, these PR would be tested with the CI
+  # They will have to be merged manually by a maintainer
+  - package-ecosystem: "gomod"
+    directory: "/"
+    open-pull-requests-limit: 10 # avoid spam, if no one reacts
+    schedule:
+      interval: "weekly"
+      time: "11:00"
+
+  # Maintain dependencies for GitHub Actions
+  # These would open PR, these PR would be tested with the CI
+  # They will have to be merged manually by a maintainer
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10 # avoid spam, if no one reacts
+    schedule:
+      interval: "weekly"
+      time: "11:00"


### PR DESCRIPTION
It will be incharge of opening PR if a Go dependency or a GHA should be updated
