### PR TITLE
chore: refactor code

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -19,9 +19,8 @@ var (
 var AddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Create an alias for an additional directory",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunAddCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunAddCmd()
 	},
 }
 

--- a/cmd/clean/clean.go
+++ b/cmd/clean/clean.go
@@ -11,9 +11,8 @@ import (
 var CleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Delete the pal aliases file",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunCleanCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunCleanCmd()
 	},
 }
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -16,9 +16,8 @@ var InstallCmd = &cobra.Command{
 	Use:     "install",
 	Short:   "Create the configuration file used by pal",
 	Aliases: []string{"i"},
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunInstallCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunInstallCmd()
 	},
 }
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -12,9 +12,8 @@ var ListCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "Display aliases in `~/pal`",
 	Aliases: []string{"ls"},
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunListCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunListCmd()
 	},
 }
 

--- a/cmd/make/make.go
+++ b/cmd/make/make.go
@@ -16,9 +16,8 @@ import (
 var MakeCmd = &cobra.Command{
 	Use:   "make",
 	Short: "Create the aliases file",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunMakeCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunMakeCmd()
 	},
 }
 

--- a/cmd/refresh/refresh.go
+++ b/cmd/refresh/refresh.go
@@ -12,9 +12,8 @@ import (
 var RefreshCmd = &cobra.Command{
 	Use:   "refresh",
 	Short: "Delete pal aliases file and run `make` command",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := RunRefreshCmd()
-		cobra.CheckErr(err)
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunRefreshCmd()
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/jaytyrrell13/pal/cmd/add"
 	"github.com/jaytyrrell13/pal/cmd/clean"
 	"github.com/jaytyrrell13/pal/cmd/install"
@@ -17,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Short: "Helps manage the aliases for your projects",
 }
 
-func Execute(version string) {
+func Execute(version string) error {
 	rootCmd.Version = version
 	rootCmd.AddCommand(add.AddCmd)
 	rootCmd.AddCommand(list.ListCmd)
@@ -26,8 +24,5 @@ func Execute(version string) {
 	rootCmd.AddCommand(clean.CleanCmd)
 	rootCmd.AddCommand(refresh.RefreshCmd)
 
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+	return rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,13 @@
 package main
 
-import "github.com/jaytyrrell13/pal/cmd"
+import (
+	"github.com/jaytyrrell13/pal/cmd"
+	"github.com/spf13/cobra"
+)
 
 var version = "dev"
 
 func main() {
-	cmd.Execute(version)
+	err := cmd.Execute(version)
+	cobra.CheckErr(err)
 }


### PR DESCRIPTION
RunE provides a better way to report errors

also os.Exit (called by cobra.CheckErr) should be avoided outside main.go
Otherwise, code is difficult to test
